### PR TITLE
Add Maven Tycho Build

### DIFF
--- a/index.bnd
+++ b/index.bnd
@@ -10,4 +10,10 @@
         description="OSGi R8 with Felix distribution", \
     mnlipp/de.mnl.osgi/de.mnl.osgi.bnd.repository/workspace-template; \
         name=IndexedMavenRepository; \
-        description="Provide an OSGi repository derived from a subset of one or more maven repositories"
+        description="Provide an OSGi repository derived from a subset of one or more maven repositories", \
+    eclipse-tycho/tycho/setup/bnd-templates/pomless; \
+        name=maven-tycho-build; \
+        description="Setup a maven pomless build for bnd workspace (IDE / bndtools first).",\
+    eclipse-tycho/tycho/setup/bnd-templates/pomless-configurator/; \
+        name=maven-tycho-build2; \
+        description="Setup a maven pomless build for bnd workspace (IDE / bndtools first) including customization using a configurator pom."


### PR DESCRIPTION
This adds a Template Fragment for a Maven build based on Eclipse Tycho which is able to build bnd workspaces with almost zero configuration: see https://tycho.eclipseprojects.io/doc/main/BndBuild.html

via the File / New / Bnd Workspace (Fragments)

<img width="589" alt="image" src="https://github.com/user-attachments/assets/f16fc39d-7960-414b-9767-0d5d1eadb5a6" />
