### PR TITLE
Fix Bundle-Version macro typo - backslash is incorrect

### DIFF
--- a/demo-webapp/org.bndtools.demo.webapp/bnd.bnd
+++ b/demo-webapp/org.bndtools.demo.webapp/bnd.bnd
@@ -10,4 +10,4 @@
 javac.source: 17
 javac.target: 17
 
-Bundle-Version: 0.1.0.\${tstamp}
+Bundle-Version: 0.1.0.${tstamp}


### PR DESCRIPTION
Even though this works inside bnd, it is not a valid java property file. Cause there must be no backslashe before dollar sign.